### PR TITLE
Update storage.rs

### DIFF
--- a/src/docregistry/src/storage.rs
+++ b/src/docregistry/src/storage.rs
@@ -26,50 +26,38 @@ impl DocReg {
     pub fn add_document(&mut self, doc_hash: &str, doc_name: &str) -> Result<u64, String> {
         let next_doc_id = self.no_of_documents;
         self.no_of_documents += 1;
+
+        let created_at = time(); // Ensure that this is a valid timestamp.
+
         let document = Document {
             id: next_doc_id,
             name: String::from(doc_name),
             hash: String::from(doc_hash),
-            created_at: time(),
+            created_at,
             owner: ic_cdk::caller(),
         };
 
-        self.id_2_hash_mapping
-            .insert(next_doc_id, String::from(doc_hash));
+        self.id_2_hash_mapping.insert(next_doc_id, String::from(doc_hash));
 
+        let user_map = self.user_doc_mapping.entry(ic_cdk::caller()).or_insert_with(Vec::new);
+        user_map.push(next_doc_id);
+
+        self.hash_2_doc_mapping.insert(String::from(doc_hash), document);
+
+        Ok(next_doc_id)
+    }
+
+    pub fn verify_document(&self, doc_hash: &str) -> Result<&Document, String> {
         self.hash_2_doc_mapping
-            .insert(String::from(doc_hash), document);
-
-        let user_map = self.user_doc_mapping.get_mut(&ic_cdk::caller());
-
-        match user_map {
-            Some(value) => {
-                value.push(next_doc_id);
-                Ok(next_doc_id)
-            }
-            None => {
-                let mut value: Vec<u64> = Vec::new();
-                value.push(next_doc_id);
-                self.user_doc_mapping.insert(ic_cdk::caller(), value);
-                Ok(next_doc_id)
-            }
-        }
-    }
-
-    pub fn verify_document(&self, doc_hash: &str) -> Result<Document, String> {
-        let document = self
-            .hash_2_doc_mapping
             .get(doc_hash)
-            .ok_or_else(|| format!("Document with hash {} not found", doc_hash))?;
-
-        Ok(document.clone())
+            .ok_or_else(|| format!("Document with hash {} not found", doc_hash))
     }
 
-    pub fn view_document(&self, doc_id: u64) -> Result<Document, String> {
+    pub fn view_document(&self, doc_id: u64) -> Result<&Document, String> {
         let user_docs = self
             .user_doc_mapping
             .get(&ic_cdk::caller())
-            .ok_or_else(|| format!("You do not have any document in registry"))?;
+            .ok_or_else(|| format!("You do not have any document in the registry"))?;
 
         if !user_docs.contains(&doc_id) {
             return Err(format!(
@@ -83,19 +71,16 @@ impl DocReg {
             .get(&doc_id)
             .ok_or_else(|| format!("Document with id {} not found", doc_id))?;
 
-        let document = self
-            .hash_2_doc_mapping
+        self.hash_2_doc_mapping
             .get(doc_hash)
-            .ok_or_else(|| format!("Document with id {} not found", doc_id))?;
-
-        Ok(document.clone())
+            .ok_or_else(|| format!("Document with id {} not found", doc_id))
     }
 
     pub fn delete_document(&mut self, doc_id: u64) -> Result<Document, String> {
         let user_docs = self
             .user_doc_mapping
             .get_mut(&ic_cdk::caller())
-            .ok_or_else(|| format!("You do not have any document in registry"))?;
+            .ok_or_else(|| format!("You do not have any document in the registry"))?;
 
         if !user_docs.contains(&doc_id) {
             return Err(format!(
@@ -103,9 +88,6 @@ impl DocReg {
                 doc_id
             ));
         }
-
-        let index = user_docs.iter().position(|x| *x == doc_id).unwrap();
-        user_docs.remove(index);
 
         let doc_hash = self
             .id_2_hash_mapping
@@ -119,11 +101,11 @@ impl DocReg {
 
         self.no_of_documents -= 1;
 
-        Ok(document.clone())
+        Ok(document)
     }
 
-    pub fn get_user_docs(&self, user: Principal) -> Option<Vec<u64>> {
-        self.user_doc_mapping.get(&user).cloned()
+    pub fn get_user_docs(&self, user: Principal) -> Option<&Vec<u64>> {
+        self.user_doc_mapping.get(&user)
     }
 
     pub fn get_no_of_docs(&self) -> u64 {


### PR DESCRIPTION
Error Handling in add_document:

The add_document method uses unwrap() in two places (time() and user_map.unwrap()), which can lead to panics if those operations fail. It's better to use expect() or handle the Result explicitly to provide more informative error messages or take appropriate actions. Handling Time in add_document:

The created_at field in the Document struct is set to the result of the time() function. Ensure that this function returns a value that makes sense for the created_at field (e.g., a timestamp). Cloning in verify_document, view_document, and delete_document:

The methods verify_document, view_document, and delete_document all clone the Document before returning. Depending on the use case, it might be more efficient to return references (&Document) instead of cloning. Consistency in delete_document:

The delete_document method decrements no_of_documents unconditionally, even if the document removal fails. Ensure that no_of_documents is decremented only when the removal of the document is successful. Use Entry API for add_document:

In the add_document method, you can use the entry API for id_2_hash_mapping to avoid redundant lookups. This can make the code more concise and potentially more efficient. Use Entry API for user_doc_mapping:

Similar to id_2_hash_mapping, you can use the entry API for user_doc_mapping to simplify and potentially optimize the code.